### PR TITLE
Add Compactable class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build status](https://travis-ci.org/LiamGoodacre/purescript-filterable.svg?branch=master)](https://travis-ci.org/LiamGoodacre/purescript-filterable)
 
-Classes for *filterable* and *witherable* data structures.
+Classes for *compactable*, *filterable*, and *witherable* data structures.
 
-Inspired by [witherable](https://hackage.haskell.org/package/witherable) on hackage.
+Inspired by [compactable](https://hackage.haskell.org/package/compactable) and [witherable](https://hackage.haskell.org/package/witherable) on hackage.
 
 ## Installation
 

--- a/src/Data/Compactable.purs
+++ b/src/Data/Compactable.purs
@@ -97,20 +97,6 @@ instance compactableMap :: Ord k => Compactable (Map.Map k) where
 mapToList :: forall k v. Ord k => Map.Map k v -> List.List (Tuple k v)
 mapToList = Map.toUnfoldable
 
-mapMaybe
-  :: forall f a b
-   . Functor f
-  => Compactable f
-  => (a -> Maybe b) -> f a -> f b
-mapMaybe p = compact <<< map p
-
-mapEither
-  :: forall f a l r
-   . Functor f
-  => Compactable f
-  => (a -> Either l r) -> f a -> { left :: f l, right :: f r }
-mapEither p = separate <<< map p
-
 applyMaybe
   :: forall f a b
    . Apply f

--- a/src/Data/Compactable.purs
+++ b/src/Data/Compactable.purs
@@ -1,0 +1,156 @@
+module Data.Compactable
+  ( class Compactable
+  , compact
+  , separate
+  , compactDefault
+  , separateDefault
+  ) where
+
+import Control.Applicative (class Applicative, class Apply, apply, pure)
+import Control.Bind (class Bind, bind, join)
+import Data.Array as Array
+import Data.Either (Either(Right, Left), hush, note)
+import Data.Foldable (class Foldable, foldl)
+import Data.Function (($))
+import Data.Functor (class Functor, map, (<$>))
+import Data.List as List
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Monoid (class Monoid, mempty, (<>))
+import Data.Traversable (class Traversable, sequence, traverse)
+import Data.Tuple (Tuple(..))
+import Prelude (class Ord, unit, (<<<))
+
+class Compactable f where
+  compact :: forall a. f (Maybe a) -> f a
+  separate :: forall l r. f (Either l r) -> { left :: f l, right :: f r }
+
+compactDefault :: forall f a. Functor f => Compactable f => f (Maybe a) -> f a
+compactDefault = _.right <<< separate <<< map (note unit)
+
+separateDefault
+  :: forall f l r
+   . Functor f
+  => Compactable f
+  => f (Either l r) -> { left :: f l, right :: f r}
+separateDefault xs = { left: compact $ (hush <<< swapEither) <$> xs
+                     , right: compact $ hush <$> xs
+                     }
+  where
+    swapEither e = case e of
+      Left x  -> Right x
+      Right y -> Left y
+
+instance compactableMaybe :: Compactable Maybe where
+  compact = join
+
+  separate Nothing = { left: Nothing, right: Nothing }
+  separate (Just e) = case e of
+    Left l  -> { left: Just l, right: Nothing }
+    Right r -> { left: Nothing, right: Just r }
+
+instance compactableEither :: Monoid m => Compactable (Either m) where
+  compact (Left m) = Left m
+  compact (Right m) = case m of
+    Just v  -> Right v
+    Nothing -> Left mempty
+
+  separate (Left x) = { left: Left x, right: Left x }
+  separate (Right e) = case e of
+    Left l  -> { left: Right l, right: Left mempty }
+    Right r -> { left: Left mempty, right: Right r }
+
+instance compactableArray :: Compactable Array where
+  compact = Array.catMaybes
+  separate xs = separateSequence xs
+
+instance compactableList :: Compactable List.List where
+  compact = List.catMaybes
+  separate xs = separateSequence xs
+
+separateSequence
+  :: forall f l r
+   . Monoid (f l)
+  => Monoid (f r)
+  => Foldable f
+  => Applicative f
+  => Compactable f
+  => f (Either l r) -> { left :: f l, right :: f r }
+separateSequence = foldl go { left: mempty, right: mempty } where
+    go acc e = case e of
+      Left l  -> acc { left = acc.left <> pure l }
+      Right r -> acc { right = acc.right <> pure r }
+
+instance compactableMap :: Ord k => Compactable (Map.Map k) where
+  compact = (Map.fromFoldable :: forall v. Array (Tuple k v) -> Map.Map k v)
+            <<< compact
+            <<< map sequence
+            <<< Map.toUnfoldable
+
+  separate m = { left: Map.fromFoldable sep.left
+               , right: Map.fromFoldable sep.right
+               }
+    where
+      sep = separate $ map distributeEither $
+            (Map.toUnfoldable :: forall v. Map.Map k v -> Array (Tuple k v)) m
+      distributeEither (Tuple k e) = case e of
+        Left l  -> Left (Tuple k l)
+        Right r -> Right (Tuple k r)
+
+mapMaybe
+  :: forall f a b
+   . Functor f
+  => Compactable f
+  => (a -> Maybe b) -> f a -> f b
+mapMaybe p = compact <<< map p
+
+mapEither
+  :: forall f a l r
+   . Functor f
+  => Compactable f
+  => (a -> Either l r) -> f a -> { left :: f l, right :: f r }
+mapEither p = separate <<< map p
+
+applyMaybe
+  :: forall f a b
+   . Apply f
+  => Compactable f
+  => f (a -> Maybe b) -> f a -> f b
+applyMaybe p = compact <<< apply p
+
+applyEither
+  :: forall f a l r
+   . Apply f
+  => Compactable f
+  => f (a -> Either l r) -> f a -> { left :: f l, right :: f r }
+applyEither p = separate <<< apply p
+
+bindMaybe
+  :: forall m a b
+   . Bind m
+  => Compactable m
+  => m a -> (a -> m (Maybe b)) -> m b
+bindMaybe x = compact <<< bind x
+
+bindEither
+  :: forall m a l r
+   . Bind m
+  => Compactable m
+  => m a -> (a -> m (Either l r)) -> { left :: m l, right :: m r }
+bindEither x = separate <<< bind x
+
+traverseMaybe
+  :: forall t m a b
+   . Applicative m
+  => Traversable t
+  => Compactable t
+  => (a -> m (Maybe b)) -> t a -> m (t b)
+traverseMaybe p = map compact <<< traverse p
+
+traverseEither
+  :: forall t m a l r
+   . Applicative m
+  => Traversable t
+  => Compactable t
+  => (a -> m (Either l r)) -> t a -> m { left :: t l, right :: t r }
+traverseEither p = map separate <<< traverse p

--- a/src/Data/Compactable.purs
+++ b/src/Data/Compactable.purs
@@ -62,14 +62,12 @@ class Compactable f where
   separate :: forall l r.
     f (Either l r) -> { left :: f l, right :: f r }
 
-compactDefault :: forall f a. Functor f => Compactable f => f (Maybe a) -> f a
+compactDefault :: forall f a. Functor f => Compactable f =>
+  f (Maybe a) -> f a
 compactDefault = _.right <<< separate <<< map (note unit)
 
-separateDefault
-  :: forall f l r
-   . Functor f
-  => Compactable f
-  => f (Either l r) -> { left :: f l, right :: f r}
+separateDefault :: forall f l r. Functor f => Compactable f =>
+  f (Either l r) -> { left :: f l, right :: f r}
 separateDefault xs = { left: compact $ (hush <<< swapEither) <$> xs
                      , right: compact $ hush <$> xs
                      }
@@ -105,12 +103,8 @@ instance compactableList :: Compactable List.List where
   compact = List.catMaybes
   separate xs = separateSequence xs
 
-separateSequence
-  :: forall f l r
-   . Alternative f
-  => Foldable f
-  => Compactable f
-  => f (Either l r) -> { left :: f l, right :: f r }
+separateSequence :: forall f l r. Alternative f => Foldable f => Compactable f =>
+  f (Either l r) -> { left :: f l, right :: f r }
 separateSequence = foldl go { left: empty, right: empty } where
     go acc = case _ of
       Left l  -> acc { left = acc.left <|> pure l }
@@ -127,33 +121,22 @@ instance compactableMap :: Ord k => Compactable (Map.Map k) where
         Left l -> { left: Map.insert k l left, right }
         Right r -> { left: left, right: Map.insert k r right }
 
-mapToList :: forall k v. Ord k => Map.Map k v -> List.List (Tuple k v)
+mapToList :: forall k v. Ord k =>
+  Map.Map k v -> List.List (Tuple k v)
 mapToList = Map.toUnfoldable
 
-applyMaybe
-  :: forall f a b
-   . Apply f
-  => Compactable f
-  => f (a -> Maybe b) -> f a -> f b
+applyMaybe :: forall f a b. Apply f => Compactable f =>
+  f (a -> Maybe b) -> f a -> f b
 applyMaybe p = compact <<< apply p
 
-applyEither
-  :: forall f a l r
-   . Apply f
-  => Compactable f
-  => f (a -> Either l r) -> f a -> { left :: f l, right :: f r }
+applyEither :: forall f a l r. Apply f => Compactable f =>
+  f (a -> Either l r) -> f a -> { left :: f l, right :: f r }
 applyEither p = separate <<< apply p
 
-bindMaybe
-  :: forall m a b
-   . Bind m
-  => Compactable m
-  => m a -> (a -> m (Maybe b)) -> m b
+bindMaybe :: forall m a b. Bind m => Compactable m =>
+  m a -> (a -> m (Maybe b)) -> m b
 bindMaybe x = compact <<< bind x
 
-bindEither
-  :: forall m a l r
-   . Bind m
-  => Compactable m
-  => m a -> (a -> m (Either l r)) -> { left :: m l, right :: m r }
+bindEither :: forall m a l r. Bind m => Compactable m =>
+  m a -> (a -> m (Either l r)) -> { left :: m l, right :: m r }
 bindEither x = separate <<< bind x

--- a/src/Data/Compactable.purs
+++ b/src/Data/Compactable.purs
@@ -21,6 +21,40 @@ import Data.Monoid (class Monoid, mempty)
 import Data.Tuple (Tuple(..))
 import Prelude (class Ord, const, unit, (<<<))
 
+-- | `Compactable` represents data structures which can be _compacted_/_filtered_.
+-- | This is a generalization of catMaybes as a new function `compact`. `compact`
+-- | has relations with `Functor`, `Applicative`, `Monad`, `Plus`, and `Traversable`
+-- | in that we can use these classes to provide the ability to operate on a data type
+-- | by eliminating intermediate Nothings. This is useful for representing the
+-- | filtering out of values, or failure.
+-- |
+-- | To be compactable alone, no laws must be satisfied other than the type signature.
+-- |
+-- | If the data type is also a Functor the following should hold:
+-- |
+-- | - Functor Identity: `compact <<< map Just ≡ id`
+-- |
+-- | According to Kmett, (Compactable f, Functor f) is a functor from the
+-- | kleisli category of Maybe to the category of Hask.
+-- | `Kleisli Maybe -> Hask`.
+-- |
+-- | If the data type is also `Applicative` the following should hold:
+-- |
+-- | - `compact <<< (pure Just <*> _) ≡ id`
+-- | - `applyMaybe (pure Just) ≡ id`
+-- | - `compact ≡ applyMaybe (pure id)`
+-- |
+-- | If the data type is also a `Monad` the following should hold:
+-- |
+-- | - `flip bindMaybe (pure <<< Just) ≡ id`
+-- | - `compact <<< (pure <<< (Just (=<<))) ≡ id`
+-- | - `compact ≡ flip bindMaybe pure`
+-- |
+-- | If the data type is also `Plus` the following should hold:
+-- |
+-- | - `compact empty ≡ empty`
+-- | - `compact (const Nothing <$> xs) ≡ empty`
+
 class Compactable f where
   compact :: forall a.
     f (Maybe a) -> f a

--- a/src/Data/Compactable.purs
+++ b/src/Data/Compactable.purs
@@ -7,7 +7,7 @@ module Data.Compactable
   ) where
 
 import Control.Alternative (class Alternative, empty, (<|>))
-import Control.Applicative (class Applicative, class Apply, apply, pure)
+import Control.Applicative (class Apply, apply, pure)
 import Control.Bind (class Bind, bind, join)
 import Data.Array as Array
 import Data.Either (Either(Right, Left), hush, note)
@@ -18,7 +18,6 @@ import Data.List as List
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Monoid (class Monoid, mempty)
-import Data.Traversable (class Traversable, traverse)
 import Data.Tuple (Tuple(..))
 import Prelude (class Ord, const, unit, (<<<))
 
@@ -124,19 +123,3 @@ bindEither
   => Compactable m
   => m a -> (a -> m (Either l r)) -> { left :: m l, right :: m r }
 bindEither x = separate <<< bind x
-
-traverseMaybe
-  :: forall t m a b
-   . Applicative m
-  => Traversable t
-  => Compactable t
-  => (a -> m (Maybe b)) -> t a -> m (t b)
-traverseMaybe p = map compact <<< traverse p
-
-traverseEither
-  :: forall t m a l r
-   . Applicative m
-  => Traversable t
-  => Compactable t
-  => (a -> m (Either l r)) -> t a -> m { left :: t l, right :: t r }
-traverseEither p = map separate <<< traverse p

--- a/src/Data/Filterable.purs
+++ b/src/Data/Filterable.purs
@@ -42,9 +42,19 @@ import Prelude (const, class Ord)
 -- | - `filter` - filter a data structure based on a boolean.
 -- |
 -- | Laws:
--- | - `map f ≡ filterMap (Just <<< f)`
+-- | - Functor Relation: `filterMap id ≡ compact`
+-- | - Functor Identity: `filterMap Just ≡ id`
+-- | - Kleisli Composition: `filterMap (l <=< r) ≡ filterMap l <<< filterMap r`
+-- |
 -- | - `filter ≡ filterMap <<< maybeBool`
 -- | - `filterMap p ≡ filter (isJust <<< p)`
+-- |
+-- | - Functor Relation: `partitionMap id ≡ separate`
+-- | - Functor Identity 1: `_.right <<< partitionMap Right ≡ id`
+-- | - Functor Identity 2: `_.left <<< partitionMap Left ≡ id`
+-- |
+-- | - `f <<< partition ≡ partitionMap <<< eitherBool` where `f = \{ no, yes } -> { left: no, right: yes }`
+-- | - `f <<< partitionMap p ≡ partition (isRight <<< p)` where `f = \{ left, right } -> { no: left, yes: right}`
 -- |
 -- | Default implementations are provided by the following functions:
 -- |

--- a/src/Data/Witherable.purs
+++ b/src/Data/Witherable.purs
@@ -34,6 +34,7 @@ import Prelude (class Ord)
 -- |
 -- | Laws:
 -- |
+-- | - Naturality: `t <<< wither f ≡ wither (t <<< f)`
 -- | - Identity: `wither (pure <<< Just) ≡ pure`
 -- | - Composition: `Compose <<< map (wither f) <<< wither g ≡ wither (Compose <<< map (wither f) <<< g)`
 -- | - Multipass partition: `wilt p ≡ map separate <<< traverse p`

--- a/src/Data/Witherable.purs
+++ b/src/Data/Witherable.purs
@@ -9,13 +9,14 @@ module Data.Witherable
   , withered
   , witherDefault
   , wiltDefault
-  , module Data.Compactable
+  , module Data.Filterable
   ) where
 
 import Control.Applicative (class Applicative, pure)
 import Control.Category ((<<<), id)
-import Data.Compactable (class Compactable, compact, separate)
+import Data.Compactable (compact, separate)
 import Data.Either (Either(..))
+import Data.Filterable (class Filterable)
 import Data.Functor (map)
 import Data.Identity (Identity(..))
 import Data.List (List)
@@ -53,7 +54,7 @@ import Prelude (class Ord)
 -- | - `partitionMapByWilt`
 -- | - `filterMapByWither`
 -- | - `traverseByWither`
-class (Compactable t, Traversable t) <= Witherable t where
+class (Filterable t, Traversable t) <= Witherable t where
   wilt :: forall m a l r. Applicative m =>
     (a -> m (Either l r)) -> t a -> m { left :: t l, right :: t r }
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,15 +1,18 @@
 module Test.Main where
 
 import Prelude
+
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
+import Data.Compactable (compact, separate)
 import Data.Either (Either(..))
 import Data.Filterable (filter, filterMap, partition, partitionMap)
 import Data.Identity (Identity(Identity))
 import Data.List (List(Nil), (:))
-import Data.Maybe (Maybe(..))
 import Data.Map (fromFoldable) as Map
+import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
+import Data.Tuple.Nested ((/\))
 import Data.Witherable (wither)
 import Test.Assert (ASSERT, assert)
 
@@ -21,9 +24,69 @@ testEqLeftRight :: ∀ a. (Ord a) => { left :: a, right :: a } -> { left :: a, r
 testEqLeftRight { left: l1, right: r1 } { left: l2, right: r2 } =
     l1 == l2 && r1 == r2
 
+testCompactable :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
+testCompactable = do
+  log "Test compactableMaybe instance" *> do
+    let parts1 = separate $ Just ((Left 1) :: Either Int Int)
+    assert $ parts1.left == Just 1
+    assert $ parts1.right == Nothing
 
-main :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
-main = do
+    let parts2 = separate $ Just ((Right 2) :: Either Int Int)
+    assert $ parts2.left == Nothing
+    assert $ parts2.right == Just 2
+
+    let parts3 = separate $ Nothing :: Maybe (Either Int Int)
+    assert $ parts3.left == Nothing
+    assert $ parts3.right == Nothing
+
+  log "Text compactableEither instance" *> do
+    let e1 = (Left [1] :: Either (Array Int) (Maybe Int))
+    assert $ compact e1 == Left [1]
+
+    let e2 = (Right Nothing :: Either (Array Int) (Maybe Int))
+    assert $ compact e2 == Left []
+
+    let e3 = (Right (Just 3) :: Either (Array Int) (Maybe Int))
+    assert $ compact e3 == Right 3
+
+    let parts1 = separate (Left [1] :: Either (Array Int) (Either Int Int))
+    assert $ parts1.left == Left [1]
+    assert $ parts1.right == Left [1]
+
+    let parts2 = separate (Right (Left 2) :: Either (Array Int) (Either Int Int))
+    assert $ parts2.left == Right 2
+    assert $ parts2.right == Left []
+
+    let parts3 = separate (Right (Right 3) :: Either (Array Int) (Either Int Int))
+    assert $ parts3.left == Left []
+    assert $ parts3.right == Right 3
+
+  log "Test compactableArray instance" *> do
+    let testList = [Left 1, Right 2, Left 3, Right 4, Left 5, Right 6, Left 7, Right 8]
+    let parts = separate testList
+    assert $ parts.left == [1, 3, 5, 7]
+    assert $ parts.right == [2, 4, 6, 8]
+
+  log "Test compactableList instance" *> do
+    let testList = (Left 1 : Right 2 : Left 3 : Right 4 : Left 5 : Right 6 : Left 7 : Right 8 : Nil)
+    let parts = separate testList
+    assert $ parts.left == (1 : 3 : 5 : 7 : Nil)
+    assert $ parts.right == (2 : 4 : 6 : 8 : Nil)
+
+  log "Test compactableMap instance" *> do
+    let m = Map.fromFoldable
+    let testCompactMap = m [1 /\ Just 1, 2 /\ Nothing, 3 /\ Just 3, 4 /\ Nothing]
+    let comparisonMapOdds = m [1 /\ 1, 3 /\ 3]
+    assert $ compact testCompactMap == comparisonMapOdds
+
+    let testSeparateMap = m [1 /\ Left 1, 2 /\ Right 2, 3 /\ Left 3, 4 /\ Right 4]
+    let comparisonMapEvens = m [2 /\ 2, 4 /\ 4]
+    let parts = separate testSeparateMap
+    assert $ parts.left == comparisonMapOdds
+    assert $ parts.right == comparisonMapEvens
+
+testFilterable :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
+testFilterable = do
   log "Test filterableMaybe instance" *> do
     let pred x = if x > 5 then Just (x * 10) else Nothing
     assert $ filterMap pred (Just 6) == Just 60
@@ -33,12 +96,6 @@ main = do
     assert $ filter (_ > 5) (Just 6) == Just 6
     assert $ filter (_ > 5) (Just 5) == Nothing
     assert $ filter (_ > 5) Nothing == Nothing
-
-  log "Test witherableMaybe instance" *> do
-    let pred x = if x > 5 then Identity (Just (x * 10)) else Identity Nothing
-    assert $ wither pred (Just 6) == Identity (Just 60)
-    assert $ wither pred (Just 5) == Identity Nothing
-    assert $ wither pred Nothing == Identity Nothing
 
   log "Test filterableList instance" *> do
     let pred x = if x > 5 then Just (x * 10) else Nothing
@@ -67,4 +124,17 @@ main = do
     assert $ partitionMap predE xs `testEqLeftRight` { left: m [Tuple 1 1, Tuple 2 2]
                                                      , right: m [Tuple 3 30, Tuple 4 40] }
 
+testWitherable :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
+testWitherable = do
+   log "Test witherableMaybe instance" *> do
+    let pred x = if x > 5 then Identity (Just (x * 10)) else Identity Nothing
+    assert $ wither pred (Just 6) == Identity (Just 60)
+    assert $ wither pred (Just 5) == Identity Nothing
+    assert $ wither pred Nothing == Identity Nothing
+
+main :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
+main = do
+  testCompactable
+  testFilterable
+  testWitherable
   log "All done!"


### PR DESCRIPTION
A port of https://hackage.haskell.org/package/Compactable-0.1.0.2/docs/Control-Compactable.html

`Compactable` doesn't require a `Functor`. In fact, some data types without a `Functor` instance _can_ have a `Compactable` instance (e.g. `Set`).

`Compactable` provides `compact` and a method I'm currently calling `separate`. These are equivalent to `Filterable`'s `filtered` and `partitioned`, respectively.

The intention with this PR is to make `Compactable` a superclass of `Filterable`.

The functions defined below the compactable instances are simply the result of adding constraints in the monad hierarchy (plus `Traversable`) and a few show up under different names in `Filterable` and `Witherable` with the following equivalences:
- `mapMaybe` -> `filterMap`
- `mapEither` -> `partitionMap`
- `traverseMaybe` -> `wither`
- `traverseEither` -> `wilt`

The functions that result from applying the other constraints (Apply and Bind) suggest other possible classes that could find a home in this library.

