### PR TITLE
Add missing exports in Data.Compactable

### DIFF
--- a/src/Data/Compactable.purs
+++ b/src/Data/Compactable.purs
@@ -4,6 +4,10 @@ module Data.Compactable
   , separate
   , compactDefault
   , separateDefault
+  , applyMaybe
+  , applyEither
+  , bindMaybe
+  , bindEither
   ) where
 
 import Control.Alternative (class Alternative, empty, (<|>))


### PR DESCRIPTION
Looks like I forgot to export these when I added them.