### PR TITLE
Update library for PureScript 0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /bower_components/
 /node_modules/
 /output/
+package-lock.json

--- a/bower.json
+++ b/bower.json
@@ -18,15 +18,15 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-foldable-traversable": "^4.0.0",
-    "purescript-identity": "^4.0.0",
-    "purescript-arrays": "^5.0.0",
-    "purescript-either": "^4.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-ordered-collections": "^1.0.0"
+    "purescript-foldable-traversable": "master",
+    "purescript-identity": "master",
+    "purescript-arrays": "master",
+    "purescript-either": "master",
+    "purescript-lists": "master",
+    "purescript-ordered-collections": "master"
   },
   "devDependencies": {
-    "purescript-assert": "^4.0.0",
-    "purescript-console": "^4.0.0"
+    "purescript-assert": "master",
+    "purescript-console": "master"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/LiamGoodacre/purescript-filterable.git"
+    "url": "https://github.com/LiamGoodacre/purescript-filterable.git"
   },
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build:docs": "rimraf docs && pulp docs"
   },
   "devDependencies": {
-    "pulp": "^12.2.0",
-    "purescript-psa": "^0.6.0",
-    "rimraf": "^2.6.2"
+    "pulp": "^15.0.0",
+    "purescript-psa": "^0.8.0",
+    "rimraf": "^3.0.2"
   }
 }

--- a/src/Data/Compactable.purs
+++ b/src/Data/Compactable.purs
@@ -105,7 +105,7 @@ instance compactableEither :: Monoid m => Compactable (Either m) where
 
 instance compactableArray :: Compactable Array where
   compact xs = ST.run do
-    result <- STA.empty
+    result <- STA.new
     iter   <- STAI.iterator (xs !! _)
 
     STAI.iterate iter $ void <<< case _ of
@@ -115,8 +115,8 @@ instance compactableArray :: Compactable Array where
     STA.unsafeFreeze result
 
   separate xs = ST.run do
-    ls <- STA.empty
-    rs <- STA.empty
+    ls <- STA.new
+    rs <- STA.new
     iter <- STAI.iterator (xs !! _)
 
     STAI.iterate iter $ void <<< case _ of


### PR DESCRIPTION
👋 Hi Liam!

This PR updates `filterable` for compatibility with PureScript 0.14. I've opened this pull request instead of waiting for the official release because `purescript-event` depends on this library, and Halogen depends on that library, and I think users would really appreciate being able to use Halogen right off the bat when PureScript 0.14 is released.

Specifically, this PR:

- Updates tooling dependencies for compatibility with the new compiler (this is backwards-compatible)
- Updates library dependencies to the relevant master branches
- Fixes warnings generated by `ST.empty` being deprecated in favor of `ST.new`.

It also takes an extra step to make the publishing process smooth for you once your dependencies have published their official releases, notably:

- Updates the Bower link to match the URL in the [purescript registry](https://github.com/purescript/registry), which is necessary when you go to release a new version.

When the compiler is released then you'll need to make a new release of this library as your dependencies have all moved up a major version. At that point, you'll need to:

1. Update your Bower file to point to the new major versions of your dependencies
2. Commit and then tag a new major version of this library
3. (Optionally) publish the new documentation to Pursuit with `pulp publish`

Once this is done I can update the relevant downstream libraries and make sure that `filterable` is up to date in the package set. Please let me know if I can be helpful with any other step!