### PR TITLE
Update dependencies to their new major versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,15 +18,15 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-foldable-traversable": "master",
-    "purescript-identity": "master",
-    "purescript-arrays": "master",
-    "purescript-either": "master",
-    "purescript-lists": "master",
-    "purescript-ordered-collections": "master"
+    "purescript-foldable-traversable": "^5.0.0",
+    "purescript-identity": "^5.0.0",
+    "purescript-arrays": "^6.0.0",
+    "purescript-either": "^5.0.0",
+    "purescript-lists": "^6.0.0",
+    "purescript-ordered-collections": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-assert": "master",
-    "purescript-console": "master"
+    "purescript-assert": "^5.0.0",
+    "purescript-console": "^5.0.0"
   }
 }


### PR DESCRIPTION
Hi @LiamGoodacre! This PR updates your Bower dependencies to their new major versions as part of the PureScript 0.14 release. From here, if you can cut a v4.0.0 release then I can make sure to get that updated in package sets as well.